### PR TITLE
Remove rules from Settings model

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -37,17 +37,4 @@ class Settings extends Model
      */
     public $nestedSettings = [];
 
-    // Public Methods
-    // =========================================================================
-
-    /**
-     * @inheritdoc
-     */
-    public function rules()
-    {
-        return [
-            ['$nestedSettings', 'array']
-        ];
-    }
-
 }


### PR DESCRIPTION
Some plugins/modules rely on reading out the Settings rules. Having the string 'array' as a placeholder causes problems. For example with the Schematic plugin https://github.com/nerds-and-company/schematic