### PR TITLE
bugfix: update FieldManipulator.js::initSettingsMenu() for Craft 4 CP JS changes

### DIFF
--- a/src/assetbundles/src/FieldManipulator.js
+++ b/src/assetbundles/src/FieldManipulator.js
@@ -439,10 +439,10 @@
                 Garnish.requestAnimationFrame($.proxy(function()
                 {
                     // Get the Garnish.MenuBtn object
-                    var menuBtn = $settingsBtn.data('menubtn') || false;
+                    var disclosureMenuBtn = $settingsBtn.data('trigger') || false;
 
                     // If there wasn’t one then fail and try again
-                    if (!menuBtn)
+                    if (!disclosureMenuBtn)
                     {
                         this.initSettingsMenu($settingsBtn, spoonedBlockTypes, $matrixField);
                         return;
@@ -452,7 +452,7 @@
                     var matrixFieldHandle = this._getMatrixFieldName($matrixField);
 
                     // Get the actual menu out of it once we get this far
-                    var $menu = menuBtn.menu.$container;
+                    var $menu = disclosureMenuBtn.$container;
                     $menu.addClass('spoon-settings-menu');
 
                     // Hide all the li’s with add block links in them


### PR DESCRIPTION
Update `FieldManipulator.js::initSettingsMenu()` to use `Garnish.DiaclosureMenu` so as to match changes to Craft 4 CP JS 

- fixes #122