### PR TITLE
Preserve spoon block type uuids when updating group settings

### DIFF
--- a/src/controllers/GroupSettingsController.php
+++ b/src/controllers/GroupSettingsController.php
@@ -137,14 +137,8 @@ class GroupSettingsController extends Controller
         // JSON decode config
         $config = Json::decode($config);
 
-        // Get any existing field layouts, so we don’t lose them
-        $fieldLayoutIds = Spoon::$plugin->blockTypes->getFieldLayoutIds($context, $fieldId);
-
         // Get old block types so we can preserve uuids for project config
         $oldBlockTypes = Spoon::$plugin->blockTypes->getByContext($context, 'matrixBlockTypeId', false, $fieldId);
-
-        // Remove all current block types by context
-        Spoon::$plugin->blockTypes->deleteByContext($context, $fieldId);
 
         // Assume no errors to start
         $errors = 0;
@@ -172,16 +166,19 @@ class GroupSettingsController extends Controller
                 // Increment the block type order
                 $blockTypeOrder++;
 
-                // Create new block type model
-                $model = new BlockTypeModel([
+                // Existing spoon block type or new with default attributes
+                $model = $oldBlockTypes[$blockTypeId][0] ?? new BlockTypeModel([
                     'fieldId' => $fieldId,
                     'matrixBlockTypeId' => $blockTypeId,
-                    'fieldLayoutId' => $fieldLayoutIds[$blockTypeId] ?? null,
+                    'uid' => StringHelper::UUID(),
+                    'context' => $context
+                ]);
+
+                // Set attributes to change
+                $model->setAttributes([
                     'groupName' => $group['name'] ?? 'missing',
-                    'context' => $context,
                     'groupSortOrder' => $groupOrder,
                     'sortOrder' => $blockTypeOrder,
-                    'uid' => $oldBlockTypes[$blockTypeId][0]['uid'] ?? StringHelper::UUID(),
                 ]);
 
                 // Attempt to save the block type

--- a/src/controllers/GroupSettingsController.php
+++ b/src/controllers/GroupSettingsController.php
@@ -140,6 +140,9 @@ class GroupSettingsController extends Controller
         // Get any existing field layouts, so we don’t lose them
         $fieldLayoutIds = Spoon::$plugin->blockTypes->getFieldLayoutIds($context, $fieldId);
 
+        // Get old block types so we can preserve uuids for project config
+        $oldBlockTypes = Spoon::$plugin->blockTypes->getByContext($context, 'matrixBlockTypeId', false, $fieldId);
+
         // Remove all current block types by context
         Spoon::$plugin->blockTypes->deleteByContext($context, $fieldId);
 
@@ -178,7 +181,7 @@ class GroupSettingsController extends Controller
                     'context' => $context,
                     'groupSortOrder' => $groupOrder,
                     'sortOrder' => $blockTypeOrder,
-                    'uid' => StringHelper::UUID(),
+                    'uid' => $oldBlockTypes[$blockTypeId][0]['uid'] ?? StringHelper::UUID(),
                 ]);
 
                 // Attempt to save the block type


### PR DESCRIPTION
First of al thanks for this plugin! We were looking for something to improve the UX of the matrix fields without having to rebuild the whole thing in something like neo, and this suits the purpose.

As mentioned in #112, currently all spoon block types are deleted and recreated when changing something in the group settings.  
With this change that still happens, however we re-use the old uuid based on matrixBlockTypeId so at least the project config files won't be deleted. My assumption is that there is one spoon block type per matrix block type, there could be something I'm overlooking.

Applying project config already seems to support updating an existing spoon block type.

## Update

We also had some problems with the blocks being temporarily gone when editing block field tabs in spoon. So have now implemented updating the spoon blocks types in stead of deleting them.